### PR TITLE
Creación de Pokemon en el mapa con click derecho

### DIFF
--- a/Assets/2D/Sprites/Mobile - Pokemon Playhouse - Pokemon.png
+++ b/Assets/2D/Sprites/Mobile - Pokemon Playhouse - Pokemon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27c41eb9be57f75cf8b1ca55cb6f0bef260ea5b3802f113ce5470651a7ae901e
+size 413198

--- a/Assets/2D/Sprites/Mobile - Pokemon Playhouse - Pokemon.png.meta
+++ b/Assets/2D/Sprites/Mobile - Pokemon Playhouse - Pokemon.png.meta
@@ -1,0 +1,1380 @@
+fileFormatVersion: 2
+guid: eb8df1625441e0f4eb4768e86c952c11
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: -7577652911592243953
+    second: Mobile - Pokemon Playhouse - Pokemon_0
+  - first:
+      213: -4082022843012622358
+    second: Mobile - Pokemon Playhouse - Pokemon_1
+  - first:
+      213: 8013534369309059266
+    second: Mobile - Pokemon Playhouse - Pokemon_2
+  - first:
+      213: 897068816839395671
+    second: Mobile - Pokemon Playhouse - Pokemon_3
+  - first:
+      213: 2278431522223894645
+    second: Mobile - Pokemon Playhouse - Pokemon_4
+  - first:
+      213: -2153721435597240369
+    second: Mobile - Pokemon Playhouse - Pokemon_5
+  - first:
+      213: -6938074587260873785
+    second: Mobile - Pokemon Playhouse - Pokemon_6
+  - first:
+      213: -8964388969315407214
+    second: Mobile - Pokemon Playhouse - Pokemon_7
+  - first:
+      213: 2951307503677059282
+    second: Mobile - Pokemon Playhouse - Pokemon_8
+  - first:
+      213: 5496529959215943775
+    second: Mobile - Pokemon Playhouse - Pokemon_9
+  - first:
+      213: -2338934919973934890
+    second: Mobile - Pokemon Playhouse - Pokemon_10
+  - first:
+      213: 3214971599150358320
+    second: Mobile - Pokemon Playhouse - Pokemon_11
+  - first:
+      213: 4679711682990816362
+    second: Mobile - Pokemon Playhouse - Pokemon_12
+  - first:
+      213: -4468291775026685400
+    second: Mobile - Pokemon Playhouse - Pokemon_13
+  - first:
+      213: 7239933335895705052
+    second: Mobile - Pokemon Playhouse - Pokemon_14
+  - first:
+      213: 6853943578256652534
+    second: Mobile - Pokemon Playhouse - Pokemon_15
+  - first:
+      213: -5191499063156058169
+    second: Mobile - Pokemon Playhouse - Pokemon_16
+  - first:
+      213: 8668723019492777008
+    second: Mobile - Pokemon Playhouse - Pokemon_17
+  - first:
+      213: -5643156897591733760
+    second: Mobile - Pokemon Playhouse - Pokemon_18
+  - first:
+      213: 1427114436390711105
+    second: Mobile - Pokemon Playhouse - Pokemon_19
+  - first:
+      213: -5055490875698077340
+    second: Mobile - Pokemon Playhouse - Pokemon_20
+  - first:
+      213: -4504339481839638358
+    second: Mobile - Pokemon Playhouse - Pokemon_21
+  - first:
+      213: 7592575807424336185
+    second: Mobile - Pokemon Playhouse - Pokemon_22
+  - first:
+      213: -6364208234181455650
+    second: Mobile - Pokemon Playhouse - Pokemon_23
+  - first:
+      213: 550520279329048665
+    second: Mobile - Pokemon Playhouse - Pokemon_24
+  - first:
+      213: 669947055564918778
+    second: Mobile - Pokemon Playhouse - Pokemon_25
+  - first:
+      213: -2783433097643419616
+    second: Mobile - Pokemon Playhouse - Pokemon_26
+  - first:
+      213: 8187076268402039675
+    second: Mobile - Pokemon Playhouse - Pokemon_27
+  - first:
+      213: 1879931853719660308
+    second: Mobile - Pokemon Playhouse - Pokemon_28
+  - first:
+      213: 8896751568216146461
+    second: Mobile - Pokemon Playhouse - Pokemon_29
+  - first:
+      213: -4032855653872743862
+    second: Mobile - Pokemon Playhouse - Pokemon_30
+  - first:
+      213: -83935481923961992
+    second: Mobile - Pokemon Playhouse - Pokemon_31
+  - first:
+      213: 8769673200062731090
+    second: Mobile - Pokemon Playhouse - Pokemon_32
+  - first:
+      213: 5106633390604086333
+    second: Mobile - Pokemon Playhouse - Pokemon_33
+  - first:
+      213: 9089001935989608532
+    second: Mobile - Pokemon Playhouse - Pokemon_34
+  - first:
+      213: -5721489026266495903
+    second: Mobile - Pokemon Playhouse - Pokemon_35
+  - first:
+      213: -1584449042987222545
+    second: Mobile - Pokemon Playhouse - Pokemon_36
+  - first:
+      213: -3320295459015607887
+    second: Mobile - Pokemon Playhouse - Pokemon_37
+  - first:
+      213: -8364112093476582985
+    second: Mobile - Pokemon Playhouse - Pokemon_38
+  - first:
+      213: 6134232888776749360
+    second: Mobile - Pokemon Playhouse - Pokemon_39
+  - first:
+      213: 8129960758952085203
+    second: Mobile - Pokemon Playhouse - Pokemon_40
+  - first:
+      213: -1506514163941503961
+    second: Mobile - Pokemon Playhouse - Pokemon_41
+  - first:
+      213: -6527771195648033338
+    second: Mobile - Pokemon Playhouse - Pokemon_42
+  - first:
+      213: -8101671725509989468
+    second: Mobile - Pokemon Playhouse - Pokemon_43
+  - first:
+      213: -7145731603130731839
+    second: Mobile - Pokemon Playhouse - Pokemon_44
+  - first:
+      213: -1075931669243242311
+    second: Mobile - Pokemon Playhouse - Pokemon_45
+  - first:
+      213: -6371572948621308206
+    second: Mobile - Pokemon Playhouse - Pokemon_46
+  - first:
+      213: 3980567898095047757
+    second: Mobile - Pokemon Playhouse - Pokemon_47
+  - first:
+      213: 1021912525163434380
+    second: Mobile - Pokemon Playhouse - Pokemon_48
+  - first:
+      213: -290868503424843547
+    second: Mobile - Pokemon Playhouse - Pokemon_49
+  - first:
+      213: 8828915292274490632
+    second: Mobile - Pokemon Playhouse - Pokemon_50
+  - first:
+      213: -6667654396963770534
+    second: Mobile - Pokemon Playhouse - Pokemon_51
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 300
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_0
+      rect:
+        serializedVersion: 2
+        x: 14
+        y: 1568
+        width: 100
+        height: 87
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: f0df65533d4c6d690800000000000000
+      internalID: -7577652911592243953
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_1
+      rect:
+        serializedVersion: 2
+        x: 151
+        y: 1560
+        width: 81
+        height: 102
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: ae7d33d0addb957c0800000000000000
+      internalID: -4082022843012622358
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_2
+      rect:
+        serializedVersion: 2
+        x: 280
+        y: 1561
+        width: 79
+        height: 101
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 2c8ec062d0bc53f60800000000000000
+      internalID: 8013534369309059266
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_3
+      rect:
+        serializedVersion: 2
+        x: 397
+        y: 1561
+        width: 101
+        height: 100
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 759cac60657037c00800000000000000
+      internalID: 897068816839395671
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_4
+      rect:
+        serializedVersion: 2
+        x: 526
+        y: 1562
+        width: 99
+        height: 99
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 5703537d56d9e9f10800000000000000
+      internalID: 2278431522223894645
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_5
+      rect:
+        serializedVersion: 2
+        x: 5
+        y: 1442
+        width: 117
+        height: 82
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: fc70516e3c17c12e0800000000000000
+      internalID: -2153721435597240369
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_6
+      rect:
+        serializedVersion: 2
+        x: 149
+        y: 1429
+        width: 86
+        height: 109
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 7c396212ce107bf90800000000000000
+      internalID: -6938074587260873785
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_7
+      rect:
+        serializedVersion: 2
+        x: 270
+        y: 1433
+        width: 100
+        height: 100
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 29a668f4ab7189380800000000000000
+      internalID: -8964388969315407214
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_8
+      rect:
+        serializedVersion: 2
+        x: 396
+        y: 1436
+        width: 104
+        height: 94
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 2d0bd93b98625f820800000000000000
+      internalID: 2951307503677059282
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_9
+      rect:
+        serializedVersion: 2
+        x: 530
+        y: 1437
+        width: 92
+        height: 92
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: f50db5440e8974c40800000000000000
+      internalID: 5496529959215943775
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_10
+      rect:
+        serializedVersion: 2
+        x: 8
+        y: 1318
+        width: 112
+        height: 74
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 6d8623e151f6a8fd0800000000000000
+      internalID: -2338934919973934890
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_11
+      rect:
+        serializedVersion: 2
+        x: 145
+        y: 1306
+        width: 93
+        height: 99
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 03f9352c2afdd9c20800000000000000
+      internalID: 3214971599150358320
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_12
+      rect:
+        serializedVersion: 2
+        x: 271
+        y: 1305
+        width: 97
+        height: 100
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a6cb9e34bfca1f040800000000000000
+      internalID: 4679711682990816362
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_13
+      rect:
+        serializedVersion: 2
+        x: 399
+        y: 1303
+        width: 98
+        height: 104
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 82a1cbcfd407df1c0800000000000000
+      internalID: -4468291775026685400
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_14
+      rect:
+        serializedVersion: 2
+        x: 529
+        y: 1308
+        width: 94
+        height: 95
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: cd5829b9209697460800000000000000
+      internalID: 7239933335895705052
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_15
+      rect:
+        serializedVersion: 2
+        x: 17
+        y: 1178
+        width: 93
+        height: 98
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 6f8be84ee591e1f50800000000000000
+      internalID: 6853943578256652534
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_16
+      rect:
+        serializedVersion: 2
+        x: 135
+        y: 1173
+        width: 113
+        height: 108
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 7c75fc89b1714f7b0800000000000000
+      internalID: -5191499063156058169
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_17
+      rect:
+        serializedVersion: 2
+        x: 258
+        y: 1183
+        width: 124
+        height: 88
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 03c5e1948ad7d4870800000000000000
+      internalID: 8668723019492777008
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_18
+      rect:
+        serializedVersion: 2
+        x: 408
+        y: 1177
+        width: 80
+        height: 100
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 002df3b43ba7fa1b0800000000000000
+      internalID: -5643156897591733760
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_19
+      rect:
+        serializedVersion: 2
+        x: 523
+        y: 1185
+        width: 106
+        height: 85
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 14f66eac4012ec310800000000000000
+      internalID: 1427114436390711105
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_20
+      rect:
+        serializedVersion: 2
+        x: 23
+        y: 1048
+        width: 82
+        height: 102
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 461a9cc65d947d9b0800000000000000
+      internalID: -5055490875698077340
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_21
+      rect:
+        serializedVersion: 2
+        x: 154
+        y: 1049
+        width: 75
+        height: 100
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: aa86e253b1f5d71c0800000000000000
+      internalID: -4504339481839638358
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_22
+      rect:
+        serializedVersion: 2
+        x: 280
+        y: 1048
+        width: 80
+        height: 102
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 93190cb387f3e5960800000000000000
+      internalID: 7592575807424336185
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_23
+      rect:
+        serializedVersion: 2
+        x: 409
+        y: 1048
+        width: 78
+        height: 102
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: ed09ffc745acda7a0800000000000000
+      internalID: -6364208234181455650
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_24
+      rect:
+        serializedVersion: 2
+        x: 537
+        y: 1044
+        width: 77
+        height: 110
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 9588e0bf647d3a700800000000000000
+      internalID: 550520279329048665
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_25
+      rect:
+        serializedVersion: 2
+        x: 18
+        y: 920
+        width: 91
+        height: 102
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: aff04492c412c4900800000000000000
+      internalID: 669947055564918778
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_26
+      rect:
+        serializedVersion: 2
+        x: 153
+        y: 919
+        width: 77
+        height: 105
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 02816ee48524f59d0800000000000000
+      internalID: -2783433097643419616
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_27
+      rect:
+        serializedVersion: 2
+        x: 285
+        y: 916
+        width: 70
+        height: 110
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: b7b52273d765e9170800000000000000
+      internalID: 8187076268402039675
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_28
+      rect:
+        serializedVersion: 2
+        x: 408
+        y: 921
+        width: 80
+        height: 100
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 417e6e68f0cd61a10800000000000000
+      internalID: 1879931853719660308
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_29
+      rect:
+        serializedVersion: 2
+        x: 514
+        y: 929
+        width: 123
+        height: 86
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: d124c6e0a6c977b70800000000000000
+      internalID: 8896751568216146461
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_30
+      rect:
+        serializedVersion: 2
+        x: 26
+        y: 792
+        width: 75
+        height: 102
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a4a4d78562b6808c0800000000000000
+      internalID: -4032855653872743862
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_31
+      rect:
+        serializedVersion: 2
+        x: 146
+        y: 793
+        width: 92
+        height: 100
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 87bfed7bf1dc5def0800000000000000
+      internalID: -83935481923961992
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_32
+      rect:
+        serializedVersion: 2
+        x: 282
+        y: 793
+        width: 76
+        height: 100
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 253900ecf4324b970800000000000000
+      internalID: 8769673200062731090
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_33
+      rect:
+        serializedVersion: 2
+        x: 410
+        y: 795
+        width: 75
+        height: 97
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: d3cea1d33086ed640800000000000000
+      internalID: 5106633390604086333
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_34
+      rect:
+        serializedVersion: 2
+        x: 534
+        y: 791
+        width: 84
+        height: 106
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 4509f7dea1f922e70800000000000000
+      internalID: 9089001935989608532
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_35
+      rect:
+        serializedVersion: 2
+        x: 15
+        y: 662
+        width: 98
+        height: 106
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 164071b5b003990b0800000000000000
+      internalID: -5721489026266495903
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_36
+      rect:
+        serializedVersion: 2
+        x: 153
+        y: 664
+        width: 78
+        height: 102
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: fe9f90c7df7e20ae0800000000000000
+      internalID: -1584449042987222545
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_37
+      rect:
+        serializedVersion: 2
+        x: 276
+        y: 668
+        width: 88
+        height: 95
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 1b938082fd0fbe1d0800000000000000
+      internalID: -3320295459015607887
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_38
+      rect:
+        serializedVersion: 2
+        x: 395
+        y: 665
+        width: 106
+        height: 100
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 7b987cead54bceb80800000000000000
+      internalID: -8364112093476582985
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_39
+      rect:
+        serializedVersion: 2
+        x: 530
+        y: 669
+        width: 91
+        height: 94
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 0317e01df4c212550800000000000000
+      internalID: 6134232888776749360
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_40
+      rect:
+        serializedVersion: 2
+        x: 10
+        y: 539
+        width: 107
+        height: 96
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 3d644336c3c63d070800000000000000
+      internalID: 8129960758952085203
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_41
+      rect:
+        serializedVersion: 2
+        x: 139
+        y: 546
+        width: 105
+        height: 83
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 72c0c298959c71be0800000000000000
+      internalID: -1506514163941503961
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_42
+      rect:
+        serializedVersion: 2
+        x: 263
+        y: 542
+        width: 113
+        height: 90
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 6cd3f54eea2b865a0800000000000000
+      internalID: -6527771195648033338
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_43
+      rect:
+        serializedVersion: 2
+        x: 386
+        y: 546
+        width: 124
+        height: 83
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 4aba62a7d74119f80800000000000000
+      internalID: -8101671725509989468
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_44
+      rect:
+        serializedVersion: 2
+        x: 520
+        y: 543
+        width: 111
+        height: 91
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 1c23c1777f245dc90800000000000000
+      internalID: -7145731603130731839
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_45
+      rect:
+        serializedVersion: 2
+        x: 9
+        y: 420
+        width: 110
+        height: 78
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 9b8d92ce8d58111f0800000000000000
+      internalID: -1075931669243242311
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_46
+      rect:
+        serializedVersion: 2
+        x: 139
+        y: 409
+        width: 106
+        height: 100
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 2de40f84920a397a0800000000000000
+      internalID: -6371572948621308206
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_47
+      rect:
+        serializedVersion: 2
+        x: 278
+        y: 406
+        width: 83
+        height: 107
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: d445742d961dd3730800000000000000
+      internalID: 3980567898095047757
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_48
+      rect:
+        serializedVersion: 2
+        x: 410
+        y: 406
+        width: 76
+        height: 106
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: c8193edf6009e2e00800000000000000
+      internalID: 1021912525163434380
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_49
+      rect:
+        serializedVersion: 2
+        x: 530
+        y: 413
+        width: 92
+        height: 92
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 5e0430123a0a6fbf0800000000000000
+      internalID: -290868503424843547
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_50
+      rect:
+        serializedVersion: 2
+        x: 16
+        y: 285
+        width: 96
+        height: 93
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 80df8044eab968a70800000000000000
+      internalID: 8828915292274490632
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Mobile - Pokemon Playhouse - Pokemon_51
+      rect:
+        serializedVersion: 2
+        x: 149
+        y: 283
+        width: 86
+        height: 97
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a5f27e717abb773a0800000000000000
+      internalID: -6667654396963770534
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 6b5bbceab08fad44e8e3f8811de2320b
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Pokemons.meta
+++ b/Assets/Pokemons.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: efdbcb8147b44a447ba40b69276f2605
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Pokemons/Prefabs.meta
+++ b/Assets/Pokemons/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e99a51c210b2c2429b23d1c6e817de2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Pokemons/Prefabs/Pokemon 1.prefab
+++ b/Assets/Pokemons/Prefabs/Pokemon 1.prefab
@@ -1,0 +1,115 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1967613327341204630
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 162122602207778572}
+  - component: {fileID: 16559546726685792}
+  m_Layer: 0
+  m_Name: Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &162122602207778572
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967613327341204630}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.35, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 5220123660061370926}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &16559546726685792
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967613327341204630}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -7577652911592243953, guid: eb8df1625441e0f4eb4768e86c952c11, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.01, y: 2.81}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &5222400152282854004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5220123660061370926}
+  m_Layer: 0
+  m_Name: Pokemon 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5220123660061370926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5222400152282854004}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.23175979, y: -0.00000047683716, z: -2.7403152}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 162122602207778572}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Pokemons/Prefabs/Pokemon 1.prefab.meta
+++ b/Assets/Pokemons/Prefabs/Pokemon 1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 040b33e7a8d664744816f7d653a29cc3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Pokemons/Prefabs/Pokemon 2.prefab
+++ b/Assets/Pokemons/Prefabs/Pokemon 2.prefab
@@ -1,0 +1,115 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1967613327341204630
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 162122602207778572}
+  - component: {fileID: 16559546726685792}
+  m_Layer: 0
+  m_Name: Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &162122602207778572
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967613327341204630}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.67, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 5220123660061370926}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &16559546726685792
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967613327341204630}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -4082022843012622358, guid: eb8df1625441e0f4eb4768e86c952c11, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.01, y: 2.81}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &5222400152282854004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5220123660061370926}
+  m_Layer: 0
+  m_Name: Pokemon 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5220123660061370926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5222400152282854004}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.23175979, y: -0.00000047683716, z: -2.7403152}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 162122602207778572}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Pokemons/Prefabs/Pokemon 2.prefab.meta
+++ b/Assets/Pokemons/Prefabs/Pokemon 2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 55132fa5417cfc44ea60a9c57efd127a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Pokemons/Prefabs/Pokemon 3.prefab
+++ b/Assets/Pokemons/Prefabs/Pokemon 3.prefab
@@ -1,0 +1,115 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1967613327341204630
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 162122602207778572}
+  - component: {fileID: 16559546726685792}
+  m_Layer: 0
+  m_Name: Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &162122602207778572
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967613327341204630}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.64, z: -0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 5220123660061370926}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &16559546726685792
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967613327341204630}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 8013534369309059266, guid: eb8df1625441e0f4eb4768e86c952c11, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.01, y: 2.81}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &5222400152282854004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5220123660061370926}
+  m_Layer: 0
+  m_Name: Pokemon 3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5220123660061370926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5222400152282854004}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.23175979, y: -0.00000047683716, z: -2.7403152}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 162122602207778572}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Pokemons/Prefabs/Pokemon 3.prefab.meta
+++ b/Assets/Pokemons/Prefabs/Pokemon 3.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4ae159a6f7ffeab4f990c6dfdc50e5a2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Pokemons/Prefabs/Pokemon 4.prefab
+++ b/Assets/Pokemons/Prefabs/Pokemon 4.prefab
@@ -1,0 +1,115 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1967613327341204630
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 162122602207778572}
+  - component: {fileID: 16559546726685792}
+  m_Layer: 0
+  m_Name: Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &162122602207778572
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967613327341204630}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.6, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 5220123660061370926}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &16559546726685792
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967613327341204630}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 897068816839395671, guid: eb8df1625441e0f4eb4768e86c952c11, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.01, y: 2.81}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &5222400152282854004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5220123660061370926}
+  m_Layer: 0
+  m_Name: Pokemon 4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5220123660061370926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5222400152282854004}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.23175979, y: -0.00000047683716, z: -2.7403152}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 162122602207778572}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Pokemons/Prefabs/Pokemon 4.prefab.meta
+++ b/Assets/Pokemons/Prefabs/Pokemon 4.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bcee64dca13fe7545858c2780015f668
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Pokemons/Prefabs/Pokemon 5.prefab
+++ b/Assets/Pokemons/Prefabs/Pokemon 5.prefab
@@ -1,0 +1,115 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1967613327341204630
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 162122602207778572}
+  - component: {fileID: 16559546726685792}
+  m_Layer: 0
+  m_Name: Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &162122602207778572
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967613327341204630}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.291, z: 0}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_Children: []
+  m_Father: {fileID: 5220123660061370926}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &16559546726685792
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1967613327341204630}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2153721435597240369, guid: eb8df1625441e0f4eb4768e86c952c11, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.01, y: 2.81}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &5222400152282854004
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5220123660061370926}
+  m_Layer: 0
+  m_Name: Pokemon 5
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5220123660061370926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5222400152282854004}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.23175979, y: -0.00000047683716, z: -2.7403152}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 162122602207778572}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Pokemons/Prefabs/Pokemon 5.prefab.meta
+++ b/Assets/Pokemons/Prefabs/Pokemon 5.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3272dc02dae34ed44a96d74842e6c7e7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Technical test.unity
+++ b/Assets/Scenes/Technical test.unity
@@ -484,6 +484,57 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &173802305
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 173802306}
+  - component: {fileID: 173802307}
+  m_Layer: 0
+  m_Name: Create pokemon from right click
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &173802306
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173802305}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1423335373}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &173802307
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173802305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30c2a9c081ac3864a85ed45197250d59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cam: {fileID: 234181019}
+  layerid: 131072
+  pokemons:
+  - {fileID: 5222400152282854004, guid: 040b33e7a8d664744816f7d653a29cc3, type: 3}
+  - {fileID: 5222400152282854004, guid: 55132fa5417cfc44ea60a9c57efd127a, type: 3}
+  - {fileID: 5222400152282854004, guid: 4ae159a6f7ffeab4f990c6dfdc50e5a2, type: 3}
+  - {fileID: 5222400152282854004, guid: bcee64dca13fe7545858c2780015f668, type: 3}
+  - {fileID: 5222400152282854004, guid: 3272dc02dae34ed44a96d74842e6c7e7, type: 3}
 --- !u!850595691 &233069156
 LightingSettings:
   m_ObjectHideFlags: 0
@@ -1620,6 +1671,37 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _statusText: {fileID: 1962332873}
+--- !u!1 &1423335372
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1423335373}
+  m_Layer: 0
+  m_Name: GameSystems
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1423335373
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1423335372}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 173802306}
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1426712541
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b634953caec37134bae6797faeb5e718
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CreatePokemonFromRightClick.cs
+++ b/Assets/Scripts/CreatePokemonFromRightClick.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CreatePokemonFromRightClick : MonoBehaviour
+{
+    [SerializeField] Camera cam;
+
+    [Tooltip("Esto debería ser 131072 (La LayerMask del RaycastPlane)")]
+    [SerializeField] int layerid; // Algún día entenderé porque las capas que trae Mapbox son tan extrañas -Juanfer
+
+    [SerializeField] GameObject[] pokemons;
+
+    LayerMask layerMask; // Layer para el Raycast
+
+    
+
+    private void Start()
+    {
+        layerMask = layerid;
+    }
+
+    private void Update()
+    {
+        // Lanzar un RayCast a la posición del mouse cuando se presiona click derecho y crear un Pokemon
+        if (Input.GetKeyDown(KeyCode.Mouse1))
+        {
+            Ray ray = cam.ScreenPointToRay(Input.mousePosition);
+            RaycastHit hit;
+
+            if (Physics.Raycast(ray, out hit, Mathf.Infinity, layerMask))
+            {
+                Vector3 positionInMap = hit.point;
+                CreatePokemon(positionInMap);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Crea un nuevo Pokemon en la escena
+    /// </summary>
+    /// <param name="position">El vector posición en donde se creará el Pokemon</param>
+    void CreatePokemon(Vector3 position)
+    {
+        int index = Random.Range(0, pokemons.Length);
+        Instantiate(pokemons[index], position, Quaternion.identity);
+    }
+}

--- a/Assets/Scripts/CreatePokemonFromRightClick.cs.meta
+++ b/Assets/Scripts/CreatePokemonFromRightClick.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30c2a9c081ac3864a85ed45197250d59
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Se implementó la funcionalidad de creación de Pokemon en el mapa con el click derecho para la prueba técnica.

Al presionar el click derecho, se crea un Pokemon donde se tenga el mouse sobre el mapa.

Se agregaron los sprites de los pokemones de https://www.spriters-resource.com/mobile/pokemonplayhouse/sheet/111737/ y se crearon prefabs con estos sprites para representar los Pokemones.

En la escena, se agrego un `gameObject` contenedor llamado **GameSystems**, en el que se ubicarían las funcionalidades de los sistemas del juego.

En `GameSystems` se agrego un objeto con el componente de `CreatePokemonFromRightClick` al cual se le deben asignar un puñado de referencias:
- Cam: La referencia a la cámara de la escena.
- Layerid: La cual debería ser 131037 (La misma Layer que posee el gameObject de RaycastPlane)
- Pokemons: Los prefabs de los pokemones que se podrán crear.

![image](https://user-images.githubusercontent.com/77905732/204047479-959d1f18-b52e-438d-8d86-cb4805a145aa.png)

Resultados:
![image](https://user-images.githubusercontent.com/77905732/204048136-973c9da7-3ab3-4748-a005-164bb9644b81.png)
